### PR TITLE
Null: Add a null event logger

### DIFF
--- a/src/Lunr/Ticks/EventLogging/Null/NullEvent.php
+++ b/src/Lunr/Ticks/EventLogging/Null/NullEvent.php
@@ -1,0 +1,273 @@
+<?php
+
+/**
+ * This file contains the Event class.
+ *
+ * SPDX-FileCopyrightText: Copyright 2025 Move Agency Group B.V., Zwolle, The Netherlands
+ * SPDX-License-Identifier: MIT
+ */
+
+namespace Lunr\Ticks\EventLogging\Null;
+
+use Lunr\Ticks\EventLogging\EventInterface;
+use Lunr\Ticks\Precision;
+
+/**
+ * Class for events.
+ *
+ * @phpstan-import-type Tags from EventInterface
+ * @phpstan-import-type Fields from EventInterface
+ */
+class NullEvent implements EventInterface
+{
+
+    /**
+     * Instance of of the Null event logger
+     * @var NullEventLogger
+     */
+    protected readonly NullEventLogger $eventLogger;
+
+    /**
+     * Constructor.
+     *
+     * @param NullEventLogger $eventLogger Instance of the NullEventLogger that created the Event
+     */
+    public function __construct(NullEventLogger $eventLogger)
+    {
+        $this->eventLogger = $eventLogger;
+    }
+
+    /**
+     * Destructor.
+     */
+    public function __destruct()
+    {
+        // no-op
+    }
+
+    /**
+     * Set event name.
+     *
+     * @param string $name Event name
+     *
+     * @return void
+     */
+    public function setName(string $name): void
+    {
+        // no-op
+    }
+
+    /**
+     * Get event name.
+     *
+     * @return string Event name
+     */
+    public function getName(): string
+    {
+        return '';
+    }
+
+    /**
+     * Set trace ID the event belongs to.
+     *
+     * @param string $traceID Trace ID
+     *
+     * @return void
+     */
+    public function setTraceId(string $traceID): void
+    {
+        // no-op
+    }
+
+    /**
+     * Get trace ID the event belongs to.
+     *
+     * @return string|null Trace ID
+     */
+    public function getTraceId(): ?string
+    {
+        return NULL;
+    }
+
+    /**
+     * Set span ID the event belongs to.
+     *
+     * @param string $spanID Span ID
+     *
+     * @return void
+     */
+    public function setSpanId(string $spanID): void
+    {
+        // no-op
+    }
+
+    /**
+     * Get span ID the event belongs to.
+     *
+     * @return string|null Span ID
+     */
+    public function getSpanId(): ?string
+    {
+        return NULL;
+    }
+
+    /**
+     * Set span ID of the parent the event belongs to.
+     *
+     * @param string $spanID Span ID
+     *
+     * @return void
+     */
+    public function setParentSpanId(string $spanID): void
+    {
+        // no-op
+    }
+
+    /**
+     * Get span ID of the parent the event belongs to.
+     *
+     * @return string|null Parent span ID
+     */
+    public function getParentSpanId(): ?string
+    {
+        return NULL;
+    }
+
+    /**
+     * Set a UUID value.
+     *
+     * @param string $key  Name for the UUID value
+     * @param string $uuid The UUID to set
+     *
+     * @return void
+     */
+    public function setUuidValue(string $key, string $uuid): void
+    {
+        // no-op
+    }
+
+    /**
+     * Set indexed metadata.
+     *
+     * This clears all previously set values and replaces them.
+     *
+     * @param Tags $tags Indexed metadata
+     *
+     * @return void
+     */
+    public function setTags(array $tags): void
+    {
+        // no-op
+    }
+
+    /**
+     * Add indexed metadata.
+     *
+     * Set new values on top of previously set values.
+     *
+     * @param Tags $tags Indexed metadata
+     *
+     * @return void
+     */
+    public function addTags(array $tags): void
+    {
+        // no-op
+    }
+
+    /**
+     * Get indexed metadata.
+     *
+     * @return Tags Indexed metadata
+     */
+    public function getTags(): array
+    {
+        return [];
+    }
+
+    /**
+     * Set unstructured metadata.
+     *
+     * This clears all previously set values and replaces them.
+     *
+     * @param Fields $fields Unstructured metadata
+     *
+     * @return void
+     */
+    public function setFields(array $fields): void
+    {
+        // no-op
+    }
+
+    /**
+     * Add unstructured metadata.
+     *
+     * Set new values on top of previously set values.
+     *
+     * @param Fields $fields Unstructured metadata
+     *
+     * @return void
+     */
+    public function addFields(array $fields): void
+    {
+        // no-op
+    }
+
+    /**
+     * Get unstructured metadata.
+     *
+     * @return Fields Unstructured metadata
+     */
+    public function getFields(): array
+    {
+        return [];
+    }
+
+    /**
+     * Record the current timestamp for the event.
+     *
+     * @param Precision $precision Timestamp precision (defaults to Nanoseconds)
+     *
+     * @return void
+     */
+    public function recordTimestamp(Precision $precision = Precision::NanoSeconds): void
+    {
+        // no-op
+    }
+
+    /**
+     * Set custom timestamp for the event.
+     *
+     * @param int|string $timestamp Timestamp
+     *
+     * @return void
+     */
+    public function setTimestamp(int|string $timestamp): void
+    {
+        // no-op
+    }
+
+    /**
+     * Return the timestamp for the event.
+     *
+     * @return int Timestamp
+     */
+    public function getTimestamp(): int
+    {
+        return -1;
+    }
+
+    /**
+     * Record the event.
+     *
+     * @param Precision $precision Timestamp precision (defaults to Nanoseconds)
+     *
+     * @return void
+     */
+    public function record($precision = Precision::NanoSeconds): void
+    {
+        // no-op
+    }
+
+}
+
+?>

--- a/src/Lunr/Ticks/EventLogging/Null/NullEventLogger.php
+++ b/src/Lunr/Ticks/EventLogging/Null/NullEventLogger.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file contains the EventLogger class.
+ *
+ * SPDX-FileCopyrightText: Copyright 2025 Move Agency Group B.V., Zwolle, The Netherlands
+ * SPDX-License-Identifier: MIT
+ */
+
+namespace Lunr\Ticks\EventLogging\Null;
+
+use Lunr\Ticks\EventLogging\EventLoggerInterface;
+
+/**
+ * Class for logging events.
+ */
+class NullEventLogger implements EventLoggerInterface
+{
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        // no-op
+    }
+
+    /**
+     * Destructor.
+     */
+    public function __destruct()
+    {
+        // no-op
+    }
+
+    /**
+     * Get an instance of a new event
+     *
+     * @param string $name Event name
+     *
+     * @return NullEvent Instance of a new NullEvent
+     */
+    public function newEvent(string $name): NullEvent
+    {
+        return new NullEvent($this);
+    }
+
+}
+
+?>

--- a/src/Lunr/Ticks/EventLogging/Null/Tests/NullEventBaseTest.php
+++ b/src/Lunr/Ticks/EventLogging/Null/Tests/NullEventBaseTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file contains the NullEventBaseTest class.
+ *
+ * SPDX-FileCopyrightText: Copyright 2025 Move Agency Group B.V., Zwolle, The Netherlands
+ * SPDX-License-Identifier: MIT
+ */
+
+namespace Lunr\Ticks\EventLogging\Null\Tests;
+
+/**
+ * This class contains tests for the EventLogger class.
+ *
+ * @covers Lunr\Ticks\EventLogging\Null\NullEvent
+ */
+class NullEventBaseTest extends NullEventTestCase
+{
+
+    /**
+     * Test that the EventLogger class is passed correctly.
+     */
+    public function testEventLoggerIsPassedCorrectly(): void
+    {
+        $this->assertPropertySame('eventLogger', $this->eventLogger);
+    }
+
+    /**
+     * Test that record() logs an event.
+     *
+     * @covers Lunr\Ticks\EventLogging\Null\NullEvent::record
+     */
+    public function testRecord(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->class->record();
+    }
+
+}
+
+?>

--- a/src/Lunr/Ticks/EventLogging/Null/Tests/NullEventGetTest.php
+++ b/src/Lunr/Ticks/EventLogging/Null/Tests/NullEventGetTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * This file contains the NullEventGetTest class.
+ *
+ * SPDX-FileCopyrightText: Copyright 2025 Move Agency Group B.V., Zwolle, The Netherlands
+ * SPDX-License-Identifier: MIT
+ */
+
+namespace Lunr\Ticks\EventLogging\Null\Tests;
+
+/**
+ * This class contains tests for the EventLogger class.
+ *
+ * @covers Lunr\Ticks\EventLogging\Null\NullEvent
+ */
+class NullEventGetTest extends NullEventTestCase
+{
+
+    /**
+     * Test that getName() gets the measurement name.
+     *
+     * @covers Lunr\Ticks\EventLogging\Null\NullEvent::getName
+     */
+    public function testGetName(): void
+    {
+        $value = $this->class->getName();
+
+        $this->assertSame('', $value);
+    }
+
+    /**
+     * Test that getTraceId() gets the Trace ID.
+     *
+     * @covers Lunr\Ticks\EventLogging\Null\NullEvent::getTraceId
+     */
+    public function testGetTraceId(): void
+    {
+        $value = $this->class->getTraceId();
+
+        $this->assertNull($value);
+    }
+
+    /**
+     * Test that getSpanId() gets the Span ID.
+     *
+     * @covers Lunr\Ticks\EventLogging\Null\NullEvent::getSpanId
+     */
+    public function testGetSpanId(): void
+    {
+        $value = $this->class->getSpanId();
+
+        $this->assertNull($value);
+    }
+
+    /**
+     * Test that getParentSpanId() gets the Span ID of the parent.
+     *
+     * @covers Lunr\Ticks\EventLogging\Null\NullEvent::getParentSpanId
+     */
+    public function testGetParentSpanId(): void
+    {
+        $value = $this->class->getParentSpanId();
+
+        $this->assertNull($value);
+    }
+
+    /**
+     * Test that getTags() gets the event tags.
+     *
+     * @covers Lunr\Ticks\EventLogging\Null\NullEvent::getTags
+     */
+    public function testGetTags(): void
+    {
+        $value = $this->class->getTags();
+
+        $this->assertArrayEmpty($value);
+    }
+
+    /**
+     * Test that getFields() gets the event fields.
+     *
+     * @covers Lunr\Ticks\EventLogging\Null\NullEvent::getFields
+     */
+    public function testGetFields(): void
+    {
+        $value = $this->class->getFields();
+
+        $this->assertArrayEmpty($value);
+    }
+
+    /**
+     * Test that getTimestamp() gets the event timestamp.
+     *
+     * @covers Lunr\Ticks\EventLogging\Null\NullEvent::getTimestamp
+     */
+    public function testGetTimestamp(): void
+    {
+        $value = $this->class->getTimestamp();
+
+        $this->assertSame(-1, $value);
+    }
+
+}
+
+?>

--- a/src/Lunr/Ticks/EventLogging/Null/Tests/NullEventLoggerNewEventTest.php
+++ b/src/Lunr/Ticks/EventLogging/Null/Tests/NullEventLoggerNewEventTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file contains the NullEventLoggerNewEventTest class.
+ *
+ * SPDX-FileCopyrightText: Copyright 2025 Move Agency Group B.V., Zwolle, The Netherlands
+ * SPDX-License-Identifier: MIT
+ */
+
+namespace Lunr\Ticks\EventLogging\Null\Tests;
+
+use Lunr\Ticks\EventLogging\Null\NullEvent;
+use ReflectionClass;
+
+/**
+ * This class contains tests for the NullEventLogger class.
+ *
+ * @covers Lunr\Ticks\EventLogging\Null\NullEventLogger
+ */
+class NullEventLoggerNewEventTest extends NullEventLoggerTestCase
+{
+
+    /**
+     * Test that newEvent() returns an Event instance.
+     *
+     * @covers Lunr\Ticks\EventLogging\Null\NullEventLogger::newEvent
+     */
+    public function testNewEvent(): void
+    {
+        $event = $this->class->newEvent('event');
+
+        $this->assertInstanceOf(NullEvent::class, $event);
+
+        $event_reflection = new ReflectionClass(NullEvent::class);
+
+        $eventLogger = $event_reflection->getProperty('eventLogger')
+                                        ->getValue($event);
+
+        $this->assertSame($this->class, $eventLogger);
+    }
+
+}
+
+?>

--- a/src/Lunr/Ticks/EventLogging/Null/Tests/NullEventLoggerTestCase.php
+++ b/src/Lunr/Ticks/EventLogging/Null/Tests/NullEventLoggerTestCase.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This file contains the NullEventLoggerTestCase class.
+ *
+ * SPDX-FileCopyrightText: Copyright 2025 Move Agency Group B.V., Zwolle, The Netherlands
+ * SPDX-License-Identifier: MIT
+ */
+
+namespace Lunr\Ticks\EventLogging\Null\Tests;
+
+use Lunr\Halo\LunrBaseTestCase;
+use Lunr\Ticks\EventLogging\Null\NullEventLogger;
+
+/**
+ * This class contains common setup routines, providers
+ * and shared attributes for testing the EventLogger class.
+ *
+ * @covers Lunr\Ticks\EventLogging\Null\NullEventLogger
+ */
+abstract class NullEventLoggerTestCase extends LunrBaseTestCase
+{
+
+    /**
+     * Instance of the tested class.
+     * @var NullEventLogger
+     */
+    protected NullEventLogger $class;
+
+    /**
+     * Testcase Constructor.
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        $this->class = new NullEventLogger();
+
+        parent::baseSetUp($this->class);
+    }
+
+    /**
+     * Testcase Destructor.
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        unset($this->class);
+    }
+
+}
+
+?>

--- a/src/Lunr/Ticks/EventLogging/Null/Tests/NullEventSetTest.php
+++ b/src/Lunr/Ticks/EventLogging/Null/Tests/NullEventSetTest.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * This file contains the NullEventSetTest class.
+ *
+ * SPDX-FileCopyrightText: Copyright 2025 Move Agency Group B.V., Zwolle, The Netherlands
+ * SPDX-License-Identifier: MIT
+ */
+
+namespace Lunr\Ticks\EventLogging\Null\Tests;
+
+use Lunr\Ticks\Precision;
+
+/**
+ * This class contains tests for the EventLogger class.
+ *
+ * @covers Lunr\Ticks\EventLogging\Null\NullEvent
+ */
+class NullEventSetTest extends NullEventTestCase
+{
+
+    /**
+     * Unit test data provider for timestamps.
+     *
+     * @return array<string, array{0: Precision, 1: int|float}>
+     */
+    public function timestampProvider(): array
+    {
+        $data = [];
+
+        $data['hours']        = [ Precision::Hours ];
+        $data['minutes']      = [ Precision::Minutes ];
+        $data['seconds']      = [ Precision::Seconds ];
+        $data['milliseconds'] = [ Precision::MilliSeconds ];
+        $data['microseconds'] = [ Precision::MicroSeconds ];
+        $data['nanoseconds']  = [ Precision::NanoSeconds ];
+
+        return $data;
+    }
+
+    /**
+     * Test that setName() sets the measurement name.
+     *
+     * @covers Lunr\Ticks\EventLogging\Null\NullEvent::setName
+     */
+    public function testSetName(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->class->setName('event');
+    }
+
+    /**
+     * Test that setTraceId() sets the Trace ID.
+     *
+     * @covers Lunr\Ticks\EventLogging\Null\NullEvent::setTraceId
+     */
+    public function testSetTraceId(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->class->setTraceId('4e122973-b870-471a-a00e-6a2778244738');
+    }
+
+    /**
+     * Test that setSpanId() sets the Span ID.
+     *
+     * @covers Lunr\Ticks\EventLogging\Null\NullEvent::setSpanId
+     */
+    public function testSetSpanId(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->class->setSpanId('4e122973-b870-471a-a00e-6a2778244738');
+    }
+
+    /**
+     * Test that setParentSpanId() sets the Span ID of the parent.
+     *
+     * @covers Lunr\Ticks\EventLogging\Null\NullEvent::setParentSpanId
+     */
+    public function testSetParentSpanId(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->class->setParentSpanId('4e122973-b870-471a-a00e-6a2778244738');
+    }
+
+    /**
+     * Test that setUuidValue() sets a UUID value.
+     *
+     * @covers Lunr\Ticks\EventLogging\Null\NullEvent::setUuidValue
+     */
+    public function testSetUuidValue(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->class->setUuidValue('contentID', '4e122973-b870-471a-a00e-6a2778244738');
+    }
+
+    /**
+     * Test that setTags() sets the event tags.
+     *
+     * @covers Lunr\Ticks\EventLogging\Null\NullEvent::setTags
+     */
+    public function testSetTags(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $tags = [ 'foo' => 'bar' ];
+
+        $this->class->setTags($tags);
+    }
+
+    /**
+     * Test that addTags() adds event tags.
+     *
+     * @covers Lunr\Ticks\EventLogging\Null\NullEvent::addTags
+     */
+    public function testAddTags(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $tags = [ 'foo' => 'bar' ];
+
+        $this->class->addTags($tags);
+    }
+
+    /**
+     * Test that setFields() sets the event fields.
+     *
+     * @covers Lunr\Ticks\EventLogging\Null\NullEvent::setFields
+     */
+    public function testSetFields(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $fields = [ 'foo' => 'bar' ];
+
+        $this->class->setFields($fields);
+    }
+
+    /**
+     * Test that addFields() adds event fields.
+     *
+     * @covers Lunr\Ticks\EventLogging\Null\NullEvent::addFields
+     */
+    public function testAddFields(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $fields = [ 'foo' => 'bar' ];
+
+        $this->class->addFields($fields);
+    }
+
+    /**
+     * Test that setTimestamp() sets the event time.
+     *
+     * @covers Lunr\Ticks\EventLogging\Null\NullEvent::setTimestamp
+     */
+    public function testSetTimestamp(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->class->setTimestamp(1730723729);
+    }
+
+    /**
+     * Test that recordTimestamp() records the current time for the event.
+     *
+     * @param Precision $precision Event precision
+     *
+     * @dataProvider timestampProvider
+     * @covers       Lunr\Ticks\EventLogging\Null\NullEvent::recordTimestamp
+     */
+    public function testRecordTimestamp(Precision $precision): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->class->recordTimestamp($precision);
+    }
+
+}
+
+?>

--- a/src/Lunr/Ticks/EventLogging/Null/Tests/NullEventTestCase.php
+++ b/src/Lunr/Ticks/EventLogging/Null/Tests/NullEventTestCase.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file contains the NullEventTestCase class.
+ *
+ * SPDX-FileCopyrightText: Copyright 2025 Move Agency Group B.V., Zwolle, The Netherlands
+ * SPDX-License-Identifier: MIT
+ */
+
+namespace Lunr\Ticks\EventLogging\Null\Tests;
+
+use Lunr\Halo\LunrBaseTestCase;
+use Lunr\Ticks\EventLogging\Null\NullEvent;
+use Lunr\Ticks\EventLogging\Null\NullEventLogger;
+
+/**
+ * This class contains common setup routines, providers
+ * and shared attributes for testing the NullEvent class.
+ *
+ * @covers Lunr\Ticks\Null\NullEventLogging\NullEvent
+ */
+abstract class NullEventTestCase extends LunrBaseTestCase
+{
+
+    /**
+     * Mock instance of the NullEventLogger class.
+     * @var NullEventLogger
+     */
+    protected NullEventLogger $eventLogger;
+
+    /**
+     * Instance of the tested class.
+     * @var NullEvent
+     */
+    protected NullEvent $class;
+
+    /**
+     * Testcase Constructor.
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        $this->eventLogger = $this->getMockBuilder(NullEventLogger::class)
+                                  ->disableOriginalConstructor()
+                                  ->getMock();
+
+        $this->class = new NullEvent($this->eventLogger);
+
+        parent::baseSetUp($this->class);
+    }
+
+    /**
+     * Testcase Destructor.
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        unset($this->eventLogger);
+        unset($this->class);
+    }
+
+}
+
+?>

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -17,6 +17,9 @@
         <testsuite name="Profling">
             <directory>../src/Lunr/Ticks/Profiling/Tests/</directory>
         </testsuite>
+        <testsuite name="NullEventLogging">
+            <directory>../src/Lunr/Ticks/EventLogging/Null/Tests/</directory>
+        </testsuite>
     </testsuites>
     <coverage>
         <include>
@@ -25,6 +28,7 @@
         <exclude>
             <directory>../src/Lunr/Ticks/Tests/</directory>
             <directory>../src/Lunr/Ticks/EventLogging/Tests/</directory>
+            <directory>../src/Lunr/Ticks/EventLogging/Null/Tests/</directory>
             <directory>../src/Lunr/Ticks/Profiling/Tests/</directory>
         </exclude>
         <report>


### PR DESCRIPTION
This is a logger that does nothing with the analytics it is given. It can be used to disable analytics in a system, or for tests when you don't want to depend on a specific implementation.

Not sure about the namespace though. `Lunr\Ticks\Null` matches the other implementations like `Lunr\Ticks\InfluxDB1`, but also we'll never have a Null profiler, so maybe we can also just somehow fold it into `Lunr\Ticks\EventLogging` directly.