### PR TITLE
EventLogging: Allow boolean tags

### DIFF
--- a/src/Lunr/Ticks/EventLogging/EventInterface.php
+++ b/src/Lunr/Ticks/EventLogging/EventInterface.php
@@ -14,7 +14,7 @@ use Lunr\Ticks\Precision;
 /**
  * Interface for events.
  *
- * @phpstan-type Tags   array<string,string|null>
+ * @phpstan-type Tags   array<string,bool|string|null>
  * @phpstan-type Fields array<string,scalar|null>
  */
 interface EventInterface


### PR DESCRIPTION
Not sure this is the best option, but it beats having call-sites littered with `? 'true' : 'false'`