### PR TITLE
General: Add method to fetch span specific tags to TracingInfoInterface

### DIFF
--- a/src/Lunr/Ticks/TracingInfoInterface.php
+++ b/src/Lunr/Ticks/TracingInfoInterface.php
@@ -9,8 +9,12 @@
 
 namespace Lunr\Ticks;
 
+use Lunr\Ticks\EventLogging\EventInterface;
+
 /**
  * Interface for accessing tracing info.
+ *
+ * @phpstan-import-type Tags from EventInterface
  */
 interface TracingInfoInterface
 {
@@ -35,6 +39,13 @@ interface TracingInfoInterface
      * @return string|null Parent span ID
      */
     public function getParentSpanId(): ?string;
+
+    /**
+     * Get tags that are specific to the current span.
+     *
+     * @return Tags Indexed metadata about the current span
+     */
+    public function getSpanSpecificTags(): array;
 
 }
 


### PR DESCRIPTION
Certain tags might differ from one Span to the other. Trace specific tags can be set using the `defaultTags` param to the constructor of the `EventLogger`, for example, but Span specific tags can't be set upfront and need to be accessible to the location that fills the event info somehow.